### PR TITLE
Fixing a typo in openstack-2021.yaml

### DIFF
--- a/_data/projects/openstack-2021.yaml
+++ b/_data/projects/openstack-2021.yaml
@@ -1,4 +1,4 @@
-name: Open Stack
+name: OpenStack
 link: https://opendev.org/openstack
 mentors:
   - name: Archana Kumari


### PR DESCRIPTION

### Description

This patch fixes the typo in the project name of OpenStack in openstack-2021.yaml.

### Type of Change:

- Documentation

### Checklist:

- [x ] My PR follows the style guidelines of this project
- [x ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**

- [x ] My changes generate no new warnings 

Signed-off-by: Ildiko Vancsa <ildiko.vancsa@gmail.com>