### PR TITLE
fix: agenda css not found

### DIFF
--- a/_pages/agenda.md
+++ b/_pages/agenda.md
@@ -4,7 +4,7 @@ permalink: /agenda/
 classes: wide
 ---
 You can contribute to projects and attend workshops in parallel 🚀
-<link rel="stylesheet" href="/assets/css/agenda.css">
+<link rel="stylesheet" href="{{ '/assets/css/agenda.css' | relative_url }}">
 <div id="agenda_schedule">
     <table id="agenda-all" class="agenda-col">
         <thead>


### PR DESCRIPTION
### Description

<!--- Include a summary of the change and relevant motivation/context. List any dependencies that are required for this change. --->

Fixes: The agenda page CSS was not loading. This issue was found via Adhoc testing.

### Type of Change:
- Documentation

### How Has This Been Tested? 
Manual local testing

### Checklist:
- [x] My PR follows the style guidelines of this project
